### PR TITLE
StateHasChanged design improvements

### DIFF
--- a/src/CloudNimble.BlazorEssentials.Breakdance/TestableWebAssemblyEnvironment.cs
+++ b/src/CloudNimble.BlazorEssentials.Breakdance/TestableWebAssemblyEnvironment.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+namespace CloudNimble.BlazorEssentials.Breakdance
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class TestableWebAssemblyHostEnvironment : IWebAssemblyHostEnvironment
+    {
+
+        #region Properties
+
+        /// <inheritdoc />
+        public string Environment { get; internal set; } = "Development";
+
+        /// <inheritdoc />
+        public string BaseAddress { get; internal set; } = "https://localhost";
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TestableWebAssemblyHostEnvironment()
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="environment"></param>
+        /// <param name="baseAddress"></param>
+        public TestableWebAssemblyHostEnvironment(string environment, string baseAddress)
+        {
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/CloudNimble.BlazorEssentials.TestApp/Models/AppState.cs
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Models/AppState.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Net.Http;
-using System.Net.NetworkInformation;
 
 namespace CloudNimble.BlazorEssentials.TestApp.Models
 {
@@ -35,10 +34,10 @@ namespace CloudNimble.BlazorEssentials.TestApp.Models
         {
             if (!Environment.IsProduction())
             {
-                StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Info;
+                StateHasChanged.DebugMode = StateHasChangedDebugMode.Info;
             }
-            StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Throttle;
-            StateHasChangedConfig.DelayInterval = 100;
+            StateHasChanged.DelayMode = StateHasChangedDelayMode.Throttle;
+            StateHasChanged.DelayInterval = 100;
 
             this.config = config;
             var nav = new List<NavigationItem>
@@ -67,7 +66,7 @@ namespace CloudNimble.BlazorEssentials.TestApp.Models
             }
             //RWM: Can't do this here because the handler is not async.
             Console.WriteLine($"AppState.{e.PropertyName} changed.");
-            StateHasChangedConfig.Action();
+            StateHasChanged.Action();
         }
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 

--- a/src/CloudNimble.BlazorEssentials.TestApp/Models/AppState.cs
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Models/AppState.cs
@@ -35,10 +35,10 @@ namespace CloudNimble.BlazorEssentials.TestApp.Models
         {
             if (!Environment.IsProduction())
             {
-                StateHasChangedDebugMode = StateHasChangedDebugMode.Info;
+                StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Info;
             }
-            StateHasChangedDelayMode = StateHasChangedDelayMode.Throttle;
-            StateHasChangedDelayInterval = 100;
+            StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Throttle;
+            StateHasChangedConfig.DelayInterval = 100;
 
             this.config = config;
             var nav = new List<NavigationItem>
@@ -67,7 +67,7 @@ namespace CloudNimble.BlazorEssentials.TestApp.Models
             }
             //RWM: Can't do this here because the handler is not async.
             Console.WriteLine($"AppState.{e.PropertyName} changed.");
-            StateHasChangedAction();
+            StateHasChangedConfig.Action();
         }
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
@@ -1,6 +1,7 @@
 ﻿@using CloudNimble.BlazorEssentials.TestApp.ViewModels;
 @using CloudNimble.BlazorEssentials.Controls;
 @using System.ComponentModel;
+@implements IDisposable
 
 @page "/DelayStateHasChanged"
 
@@ -60,5 +61,10 @@ else
             await Task.Delay(fireInterval);
             viewModel.StateHasChangedConfig.Action();
         }
+    }
+
+    public void Dispose()
+    {
+        rapidFire = false;
     }
 }

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
@@ -1,37 +1,35 @@
 ﻿@using CloudNimble.BlazorEssentials.TestApp.ViewModels;
 @using CloudNimble.BlazorEssentials.Controls;
 @using System.ComponentModel;
-@implements IDisposable
 
 @page "/DelayStateHasChanged"
-
+@implements IDisposable
 @inject DelayStateHasChangedViewModel viewModel
 
-
-<p>This page showcases the delay that we have on the <code>StateHasChangedConfig.Action</code> so that rapid calls get ignored.</p>
+<p>This page showcases the delay that we have on the <code>StateHasChanged.Action</code> so that rapid calls get ignored.</p>
 
 <hr />
 
 @if (rapidFire)
 {
-    <button class="btn btn-warning" @onclick="ToggleRapidFire">Press button to stop rapid firing StateHasChangedConfig.Action</button>
+    <button class="btn btn-warning" @onclick="ToggleRapidFire">Press button to stop rapid firing StateHasChanged.Action</button>
 }
 else
 {
-    <button class="btn btn-success" @onclick="ToggleRapidFire">Press button to start rapid firing StateHasChangedConfig.Action</button>
+    <button class="btn btn-success" @onclick="ToggleRapidFire">Press button to start rapid firing StateHasChanged.Action</button>
 }
 <br />
 <br />
-<label class="form-label">Delay Mode (@viewModel.StateHasChangedConfig.DelayMode.ToString())</label>
+<label class="form-label">Delay Mode (@viewModel.StateHasChanged.DelayMode.ToString())</label>
 <br />
 @foreach (StateHasChangedDelayMode mode in Enum.GetValues(typeof(StateHasChangedDelayMode)))
 {
-    <button class="btn btn-primary px-1" @onclick="()=>viewModel.StateHasChangedConfig.DelayMode = mode">@mode.ToString()</button>
+    <button class="btn btn-primary px-1" @onclick="()=>viewModel.StateHasChanged.DelayMode = mode">@mode.ToString()</button>
 }
 <br />
 
-<label for="delayInterval" class="form-label">Delay Interval (@viewModel.StateHasChangedConfig.DelayInterval)</label>
-<input @bind-value=viewModel.StateHasChangedConfig.DelayInterval id="delayInterval" type="range" class="form-range" min="10" max="4000" step="10" />
+<label for="delayInterval" class="form-label">Delay Interval (@viewModel.StateHasChanged.DelayInterval)</label>
+<input @bind-value=viewModel.StateHasChanged.DelayInterval id="delayInterval" type="range" class="form-range" min="10" max="4000" step="10" />
 <label for="updateInterval" class="form-label">Rapid Fire Interval (@fireInterval)</label>
 <input @bind-value=fireInterval id="updateInterval" type="range" class="form-range" min="1" max="2000" step="1" />
 <hr />
@@ -46,7 +44,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedConfig.Action = () =>
+        viewModel.StateHasChanged.Action = () =>
         {
             printOut = $"StateHasChanged at {DateTime.UtcNow.Second.ToString("D2") + ":" + DateTime.UtcNow.Millisecond.ToString("D3")}\n" + printOut;
             StateHasChanged();
@@ -59,7 +57,7 @@ else
         while (rapidFire)
         {
             await Task.Delay(fireInterval);
-            viewModel.StateHasChangedConfig.Action();
+            viewModel.StateHasChanged.Action();
         }
     }
 

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/DelayStateHasChanged.razor
@@ -7,30 +7,30 @@
 @inject DelayStateHasChangedViewModel viewModel
 
 
-<p>This page showcases the delay that we have on the <code>StateHasChangedAction</code> so that rapid calls get ignored.</p>
+<p>This page showcases the delay that we have on the <code>StateHasChangedConfig.Action</code> so that rapid calls get ignored.</p>
 
 <hr />
 
 @if (rapidFire)
 {
-    <button class="btn btn-warning" @onclick="ToggleRapidFire">Press button to stop rapid firing StateHasChangedAction</button>
+    <button class="btn btn-warning" @onclick="ToggleRapidFire">Press button to stop rapid firing StateHasChangedConfig.Action</button>
 }
 else
 {
-    <button class="btn btn-success" @onclick="ToggleRapidFire">Press button to start rapid firing StateHasChangedAction</button>
+    <button class="btn btn-success" @onclick="ToggleRapidFire">Press button to start rapid firing StateHasChangedConfig.Action</button>
 }
 <br />
 <br />
-<label class="form-label">Delay Mode (@viewModel.StateHasChangedDelayMode.ToString())</label>
+<label class="form-label">Delay Mode (@viewModel.StateHasChangedConfig.DelayMode.ToString())</label>
 <br />
 @foreach (StateHasChangedDelayMode mode in Enum.GetValues(typeof(StateHasChangedDelayMode)))
 {
-    <button class="btn btn-primary px-1" @onclick="()=>viewModel.StateHasChangedDelayMode = mode">@mode.ToString()</button>
+    <button class="btn btn-primary px-1" @onclick="()=>viewModel.StateHasChangedConfig.DelayMode = mode">@mode.ToString()</button>
 }
 <br />
 
-<label for="delayInterval" class="form-label">Delay Interval (@viewModel.StateHasChangedDelayInterval)</label>
-<input @bind-value=viewModel.StateHasChangedDelayInterval id="delayInterval" type="range" class="form-range" min="10" max="4000" step="10" />
+<label for="delayInterval" class="form-label">Delay Interval (@viewModel.StateHasChangedConfig.DelayInterval)</label>
+<input @bind-value=viewModel.StateHasChangedConfig.DelayInterval id="delayInterval" type="range" class="form-range" min="10" max="4000" step="10" />
 <label for="updateInterval" class="form-label">Rapid Fire Interval (@fireInterval)</label>
 <input @bind-value=fireInterval id="updateInterval" type="range" class="form-range" min="1" max="2000" step="1" />
 <hr />
@@ -45,7 +45,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedAction = () =>
+        viewModel.StateHasChangedConfig.Action = () =>
         {
             printOut = $"StateHasChanged at {DateTime.UtcNow.Second.ToString("D2") + ":" + DateTime.UtcNow.Millisecond.ToString("D3")}\n" + printOut;
             StateHasChanged();
@@ -58,7 +58,7 @@ else
         while (rapidFire)
         {
             await Task.Delay(fireInterval);
-            viewModel.StateHasChangedAction();
+            viewModel.StateHasChangedConfig.Action();
         }
     }
 }

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/Index.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/Index.razor
@@ -27,7 +27,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedAction = StateHasChanged;
+        viewModel.StateHasChangedConfig.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/Index.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/Index.razor
@@ -27,7 +27,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedConfig.Action = StateHasChanged;
+        viewModel.StateHasChanged.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/LoadingContainerDemo.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/LoadingContainerDemo.razor
@@ -64,7 +64,7 @@
 {
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedAction = StateHasChanged;
+        viewModel.StateHasChangedConfig.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/LoadingContainerDemo.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/LoadingContainerDemo.razor
@@ -64,7 +64,7 @@
 {
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedConfig.Action = StateHasChanged;
+        viewModel.StateHasChanged.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/MerlinWizard.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/MerlinWizard.razor
@@ -74,7 +74,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedConfig.Action = StateHasChanged;
+        viewModel.StateHasChanged.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Pages/MerlinWizard.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Pages/MerlinWizard.razor
@@ -74,7 +74,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        viewModel.StateHasChangedAction = StateHasChanged;
+        viewModel.StateHasChangedConfig.Action = StateHasChanged;
         viewModel.PropertyChanged += (sender, e) =>
         {
             this.StateHasChanged();

--- a/src/CloudNimble.BlazorEssentials.TestApp/Shared/MainLayout.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Shared/MainLayout.razor
@@ -46,7 +46,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        appState.StateHasChangedAction += StateHasChanged;
+        appState.StateHasChangedConfig.Action = StateHasChanged;
 
         //appState.AuthenticationStateProvider = AuthenticationStateProvider;
         //await appState.RefreshClaimsPrincipal();
@@ -59,7 +59,7 @@
 
     public void Dispose()
     {
-        appState.StateHasChangedAction -= StateHasChanged;
+        appState.StateHasChangedConfig.Action -= StateHasChanged;
     }
 
 }

--- a/src/CloudNimble.BlazorEssentials.TestApp/Shared/MainLayout.razor
+++ b/src/CloudNimble.BlazorEssentials.TestApp/Shared/MainLayout.razor
@@ -46,7 +46,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        appState.StateHasChangedConfig.Action = StateHasChanged;
+        appState.StateHasChanged.Action = StateHasChanged;
 
         //appState.AuthenticationStateProvider = AuthenticationStateProvider;
         //await appState.RefreshClaimsPrincipal();
@@ -59,7 +59,7 @@
 
     public void Dispose()
     {
-        appState.StateHasChangedConfig.Action -= StateHasChanged;
+        appState.StateHasChanged.Action -= StateHasChanged;
     }
 
 }

--- a/src/CloudNimble.BlazorEssentials.TestApp/ViewModels/DelayStateHasChangedViewModel.cs
+++ b/src/CloudNimble.BlazorEssentials.TestApp/ViewModels/DelayStateHasChangedViewModel.cs
@@ -5,16 +5,20 @@ using System.Net.Http;
 
 namespace CloudNimble.BlazorEssentials.TestApp.ViewModels
 {
+
     public class DelayStateHasChangedViewModel : ViewModelBase<ConfigurationBase, AppState>
     {
+
         #region Constructors
 
         public DelayStateHasChangedViewModel(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, ConfigurationBase configuration = null, AppState appState = null) : base(navigationManager, httpClientFactory, configuration, appState)
         {
-            StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Tuning;
-            appState.StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Tuning;
+            StateHasChanged.DebugMode = StateHasChangedDebugMode.Tuning;
+            appState.StateHasChanged.DebugMode = StateHasChangedDebugMode.Tuning;
         }
 
         #endregion
+
     }
+
 }

--- a/src/CloudNimble.BlazorEssentials.TestApp/ViewModels/DelayStateHasChangedViewModel.cs
+++ b/src/CloudNimble.BlazorEssentials.TestApp/ViewModels/DelayStateHasChangedViewModel.cs
@@ -11,8 +11,8 @@ namespace CloudNimble.BlazorEssentials.TestApp.ViewModels
 
         public DelayStateHasChangedViewModel(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, ConfigurationBase configuration = null, AppState appState = null) : base(navigationManager, httpClientFactory, configuration, appState)
         {
-            StateHasChangedDebugMode = StateHasChangedDebugMode.Tuning;
-            appState.StateHasChangedDebugMode = StateHasChangedDebugMode.Tuning;
+            StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Tuning;
+            appState.StateHasChangedConfig.DebugMode = StateHasChangedDebugMode.Tuning;
         }
 
         #endregion

--- a/src/CloudNimble.BlazorEssentials.TestApp/wwwroot/appsettings.json
+++ b/src/CloudNimble.BlazorEssentials.TestApp/wwwroot/appsettings.json
@@ -1,7 +1,7 @@
 {
   "TestApp": {
     "ApiClientName": "ApiClient",
-    "ApiRoot": "https://catalog.data.gov/api/3/",
+    "ApiRoot": "http://demo.ckan.org/api/action/package_list",
     "HttpHandlerMode": "None"
   }
 }

--- a/src/CloudNimble.BlazorEssentials.Tests.TestApp/AppStateBaseTests.cs
+++ b/src/CloudNimble.BlazorEssentials.Tests.TestApp/AppStateBaseTests.cs
@@ -4,6 +4,7 @@ using CloudNimble.BlazorEssentials.TestApp.ViewModels;
 using CloudNimble.EasyAF.Configuration;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,6 +25,7 @@ namespace CloudNimble.BlazorEssentials.Tests.TestApp
         public void Setup()
         {
             RegisterServices = services => {
+                services.AddSingleton<IWebAssemblyHostEnvironment, TestableWebAssemblyHostEnvironment>();
                 services.AddScoped<AuthenticationStateProvider, TestableAuthenticationStateProvider>();
             };
             TestSetup("TestApp");

--- a/src/CloudNimble.BlazorEssentials.Tests.TestApp/LoadingContainerViewModelTests.cs
+++ b/src/CloudNimble.BlazorEssentials.Tests.TestApp/LoadingContainerViewModelTests.cs
@@ -3,6 +3,7 @@ using CloudNimble.BlazorEssentials.TestApp.Models;
 using CloudNimble.BlazorEssentials.TestApp.ViewModels;
 using CloudNimble.EasyAF.Configuration;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
@@ -24,6 +25,7 @@ namespace CloudNimble.BlazorEssentials.Tests.TestApp
         public void Setup()
         {
             RegisterServices = services => {
+                services.AddSingleton<IWebAssemblyHostEnvironment, TestableWebAssemblyHostEnvironment>();
                 services.AddSingleton<LoadingContainerViewModel>();
             };
             TestSetup("TestApp");

--- a/src/CloudNimble.BlazorEssentials.Tests/BlazorObservableTests.cs
+++ b/src/CloudNimble.BlazorEssentials.Tests/BlazorObservableTests.cs
@@ -1,0 +1,69 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudNimble.BlazorEssentials.Tests
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [TestClass]
+    public class BlazorObservableTests
+    {
+        [TestMethod]
+        public async Task BlazorObservable_Delay_Off()
+        {
+            var blazorObservable = new BlazorObservable();
+            var count = 0;
+            blazorObservable.StateHasChangedConfig.Action = () => count++;
+            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Off;
+
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Delay(20);
+                blazorObservable.StateHasChangedConfig.Action();
+            }
+            count.Should().Be(10);
+        }
+
+        [TestMethod]
+        public async Task BlazorObservable_Delay_Debounce()
+        {
+            var blazorObservable = new BlazorObservable();
+            var count = 0;
+            blazorObservable.StateHasChangedConfig.Action = () => count++;
+            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Debounce;
+            blazorObservable.StateHasChangedConfig.DelayInterval = 30;
+
+            for (int i = 0; i < 10; i++)
+            {
+                await Task.Delay(10);
+                blazorObservable.StateHasChangedConfig.Action();
+            }
+            await Task.Delay(40);
+            count.Should().Be(1);
+        }
+
+        [TestMethod]
+        public async Task BlazorObservable_Delay_Throttle()
+        {
+            var blazorObservable = new BlazorObservable();
+            var count = 0;
+            blazorObservable.StateHasChangedConfig.Action = () => count++;
+            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Throttle;
+            blazorObservable.StateHasChangedConfig.DelayInterval = 30;
+
+            for (int i = 0; i < 9; i++)
+            {
+                await Task.Delay(10);
+                blazorObservable.StateHasChangedConfig.Action();
+            }
+            await Task.Delay(20);
+            count.Should().Be(3);
+        }
+    }
+}

--- a/src/CloudNimble.BlazorEssentials.Tests/BlazorObservableTests.cs
+++ b/src/CloudNimble.BlazorEssentials.Tests/BlazorObservableTests.cs
@@ -1,9 +1,5 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace CloudNimble.BlazorEssentials.Tests
@@ -19,13 +15,13 @@ namespace CloudNimble.BlazorEssentials.Tests
         {
             var blazorObservable = new BlazorObservable();
             var count = 0;
-            blazorObservable.StateHasChangedConfig.Action = () => count++;
-            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Off;
+            blazorObservable.StateHasChanged.Action = () => count++;
+            blazorObservable.StateHasChanged.DelayMode = StateHasChangedDelayMode.Off;
 
             for (int i = 0; i < 10; i++)
             {
                 await Task.Delay(20);
-                blazorObservable.StateHasChangedConfig.Action();
+                blazorObservable.StateHasChanged.Action();
             }
             count.Should().Be(10);
         }
@@ -35,16 +31,16 @@ namespace CloudNimble.BlazorEssentials.Tests
         {
             var blazorObservable = new BlazorObservable();
             var count = 0;
-            blazorObservable.StateHasChangedConfig.Action = () => count++;
-            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Debounce;
-            blazorObservable.StateHasChangedConfig.DelayInterval = 30;
+            blazorObservable.StateHasChanged.Action = () => count++;
+            blazorObservable.StateHasChanged.DelayMode = StateHasChangedDelayMode.Debounce;
+            blazorObservable.StateHasChanged.DelayInterval = 30;
 
             for (int i = 0; i < 10; i++)
             {
                 await Task.Delay(10);
-                blazorObservable.StateHasChangedConfig.Action();
+                blazorObservable.StateHasChanged.Action();
             }
-            await Task.Delay(40);
+            await Task.Delay(50);
             count.Should().Be(1);
         }
 
@@ -53,14 +49,14 @@ namespace CloudNimble.BlazorEssentials.Tests
         {
             var blazorObservable = new BlazorObservable();
             var count = 0;
-            blazorObservable.StateHasChangedConfig.Action = () => count++;
-            blazorObservable.StateHasChangedConfig.DelayMode = StateHasChangedDelayMode.Throttle;
-            blazorObservable.StateHasChangedConfig.DelayInterval = 30;
+            blazorObservable.StateHasChanged.Action = () => count++;
+            blazorObservable.StateHasChanged.DelayMode = StateHasChangedDelayMode.Throttle;
+            blazorObservable.StateHasChanged.DelayInterval = 30;
 
             for (int i = 0; i < 9; i++)
             {
                 await Task.Delay(10);
-                blazorObservable.StateHasChangedConfig.Action();
+                blazorObservable.StateHasChanged.Action();
             }
             await Task.Delay(20);
             count.Should().Be(3);

--- a/src/CloudNimble.BlazorEssentials/AppStateBase.cs
+++ b/src/CloudNimble.BlazorEssentials/AppStateBase.cs
@@ -105,9 +105,11 @@ namespace CloudNimble.BlazorEssentials
         /// 
         /// </summary>
         /// <param name="environment"></param>
+        /// <param name="stateHasChangedConfig"></param>
         /// <param name="navigationManager"></param>
         /// <param name="httpClientFactory"></param>
-        public AppStateBase(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, IWebAssemblyHostEnvironment environment = null)
+        public AppStateBase(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, IWebAssemblyHostEnvironment environment = null, StateHasChangedConfig stateHasChangedConfig = null)
+            : base(stateHasChangedConfig)
         {
             HttpClientFactory = httpClientFactory;
             NavigationManager = navigationManager;

--- a/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
+++ b/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
@@ -34,7 +34,7 @@ namespace CloudNimble.BlazorEssentials
 
         #region Constructor
 
-        /// <summary>C# get calling typoe
+        /// <summary>
         /// Creates a new instance of the <see cref="BlazorObservable" /> class.
         /// </summary>
         public BlazorObservable(StateHasChangedConfig stateHasChangedConfig = null)

--- a/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
+++ b/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
@@ -16,8 +16,6 @@ namespace CloudNimble.BlazorEssentials
 
         private bool disposedValue;
         private LoadingStatus loadingStatus;
-        private Action stateHasChangedAction;
-        private readonly DelayDispatcher delayDispatcher = new();
 
         #endregion
 
@@ -32,61 +30,7 @@ namespace CloudNimble.BlazorEssentials
             set => Set(() => LoadingStatus, ref loadingStatus, value);
         }
 
-        /// <summary>
-        /// Allows the current Blazor container to pass the StateHasChanged action back to the BlazorObservable so ViewModel operations can 
-        /// trigger state changes.
-        /// </summary>
-        /// <remarks>
-        /// Will optionally drop intermediate StateHasChanged calls in a rapidly-updating environment, based on <see cref="StateHasChangedDelayMode"/> 
-        /// and <see cref="StateHasChangedDelayInterval"/>.
-        /// </remarks>
-        public Action StateHasChangedAction
-        {
-            get
-            {
-                return StateHasChangedDelayMode switch
-                {
-                    StateHasChangedDelayMode.Debounce => () => delayDispatcher.Debounce(StateHasChangedDelayInterval, _ => StateHasChangedInternal()),
-                    StateHasChangedDelayMode.Throttle => () => delayDispatcher.Throttle(StateHasChangedDelayInterval, _ => StateHasChangedInternal()),
-                    _ => () => StateHasChangedInternal()
-                };
-            }
-            set
-            {
-                stateHasChangedAction = value;
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <remarks>
-        /// This is public so 
-        /// </remarks>
-        public int StateHasChangedCount { get; set; }
-
-        /// <summary>
-        /// Flag for whether or not the render count and helpful debug feedback/warnings should be logged to the <see cref="Console"/>.
-        /// Default is false.
-        /// </summary>
-        public StateHasChangedDebugMode StateHasChangedDebugMode { get; set; }
-
-        /// <summary>
-        /// An <see cref="int"/> specifying the number of milliseconds this BlazorObservable should wait between 
-        /// <see cref="StateHasChangedAction"/> calls. Default is 100 miliseconds.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="StateHasChangedDelayMode" /> must be set to <see cref="StateHasChangedDelayMode.Debounce" /> or 
-        /// <see cref="StateHasChangedDelayMode.Throttle" /> for this setting to take effect.
-        /// </remarks>
-        public int StateHasChangedDelayInterval { get; set; } = 100;
-
-        /// <summary>
-        /// A <see cref="StateHasChangedDelayMode" /> indicating whether or not this BlazorObservable should reduce the number of times
-        /// <see cref="StateHasChangedAction" /> should be called in a given <see cref="StateHasChangedDelayInterval" />
-        /// Default is <see cref="StateHasChangedDelayMode.Off"/>.
-        /// </summary>
-        public StateHasChangedDelayMode StateHasChangedDelayMode { get; set; } = StateHasChangedDelayMode.Off;
+        public StateHasChangedConfig StateHasChangedConfig { get; set; }
 
         #endregion
 
@@ -95,73 +39,17 @@ namespace CloudNimble.BlazorEssentials
         /// <summary>
         /// Creates a new instance of the <see cref="BlazorObservable" /> class.
         /// </summary>
-        public BlazorObservable()
+        public BlazorObservable(StateHasChangedConfig stateHasChangedConfig = null)
         {
-           stateHasChangedAction = () =>
-           {
-               if (StateHasChangedDebugMode != StateHasChangedDebugMode.Off)
-               {
-                   Console.WriteLine($"WARNING: {GetType().Name} called empty StateHasChangedAction. Make sure to set `[YourViewModel].StateHasChangedAction = StateHasChanged;` in OnInitializedAsync()");
-               }
-           };
-        }
-
-        #endregion
-
-        #region Private Methods
-
-        /// <summary>
-        /// 
-        /// </summary>
-        internal void LogDelay()
-        {
-            Console.WriteLine($"{GetType().Name}: StateHasChanged #{StateHasChangedCount} called @ {DateTime.UtcNow.ToString("hh:mm:ss.fff", CultureInfo.InvariantCulture)} " +
-                $"{(StateHasChangedDebugMode != StateHasChangedDebugMode.Off ? $"after {delayDispatcher.DelayCount} dropped calls." : "")}");
-
-            if (StateHasChangedDebugMode != StateHasChangedDebugMode.Tuning || StateHasChangedDelayMode == StateHasChangedDelayMode.Off) return;
-
-            var diffMiliseconds = DateTime.UtcNow.Subtract(delayDispatcher.TimerStarted).TotalMilliseconds;
-
-            // RWM: We're going to use a Tuple switch statement to simplify 
-            var entry = (StateHasChangedDelayMode, StateHasChangedDelayInterval, delayDispatcher.DelayCount, diffMiliseconds) switch
+            StateHasChangedConfig = stateHasChangedConfig ?? new();
+            StateHasChangedConfig.BlazorObservable = this;
+            StateHasChangedConfig.Action = () =>
             {
-                (StateHasChangedDelayMode.Debounce, _, _, < 50) => $"Performance: Debounce waited {diffMiliseconds}ms between calls. Delay was imperceptible.",
-
-                (StateHasChangedDelayMode.Debounce, _, _, < 2000) => $"Performance: Debounce waited {diffMiliseconds}ms between calls. Delay was noticeable.",
-
-                (StateHasChangedDelayMode.Throttle, < 50, _, _) => $"Performance: Throttle waited {StateHasChangedDelayInterval}ms between calls. Delay was imperceptible.",
-
-                (StateHasChangedDelayMode.Throttle, < 2000, < 10, _) => $"Performance: Throttle waited {StateHasChangedDelayInterval}ms between calls," +
-                    $" but there were fewer than 10 calls dropped. Delay was imperceptible, but consider using Debounce instead.",
-
-                (StateHasChangedDelayMode.Throttle, < 2000, _, _) => $"Performance: Throttle waited {StateHasChangedDelayInterval}ms between calls." +
-                    $" If your goal is to reduce the number of repaints but fire them consistently, this is the right setting.",
-
-                _ => $"Performance: {StateHasChangedDelayMode} waited {(StateHasChangedDelayMode == StateHasChangedDelayMode.Debounce ? diffMiliseconds : StateHasChangedDelayInterval)}ms " +
-                    $"between calls. Delay was unacceptable. Consider adding a visual 'waiting' indicator for the end user."
+                if (StateHasChangedConfig.DebugMode != StateHasChangedDebugMode.Off)
+                {
+                    Console.WriteLine($"WARNING: {GetType().Name} called empty StateHasChangedConfig.Action. Make sure to set `[YourViewModel].StateHasChangedConfig.Action = StateHasChanged;` in OnInitializedAsync()");
+                }
             };
-
-            //if (string.IsNullOrWhiteSpace(entry)) return;
-            Console.WriteLine(entry);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <remarks>
-        /// RWM: DO NOT change this method. Doing anything other than returning the StateHasChangedAction
-        /// will cause an infinite loop!
-        /// </remarks>
-        internal Action StateHasChangedInternal()
-        {
-            ++StateHasChangedCount;
-
-            if (StateHasChangedDebugMode != StateHasChangedDebugMode.Off)
-            {
-                LogDelay();
-            }
-
-            return stateHasChangedAction;
         }
 
         #endregion
@@ -178,7 +66,7 @@ namespace CloudNimble.BlazorEssentials
             {
                 if (disposing)
                 {
-                    delayDispatcher.Dispose();
+                    // Dispose here
                 }
 
                 disposedValue = true;

--- a/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
+++ b/src/CloudNimble.BlazorEssentials/BlazorObservable.cs
@@ -1,7 +1,5 @@
-﻿using CloudNimble.BlazorEssentials.Threading;
-using CloudNimble.EasyAF.Core;
+﻿using CloudNimble.EasyAF.Core;
 using System;
-using System.Globalization;
 
 namespace CloudNimble.BlazorEssentials
 {
@@ -30,24 +28,23 @@ namespace CloudNimble.BlazorEssentials
             set => Set(() => LoadingStatus, ref loadingStatus, value);
         }
 
-        public StateHasChangedConfig StateHasChangedConfig { get; set; }
+        public StateHasChangedConfig StateHasChanged { get; set; }
 
         #endregion
 
         #region Constructor
 
-        /// <summary>
+        /// <summary>C# get calling typoe
         /// Creates a new instance of the <see cref="BlazorObservable" /> class.
         /// </summary>
         public BlazorObservable(StateHasChangedConfig stateHasChangedConfig = null)
         {
-            StateHasChangedConfig = stateHasChangedConfig ?? new();
-            StateHasChangedConfig.BlazorObservable = this;
-            StateHasChangedConfig.Action = () =>
+            StateHasChanged = stateHasChangedConfig?.Clone(this) ?? new() { BlazorObservableType = GetType() };
+            StateHasChanged.Action = () =>
             {
-                if (StateHasChangedConfig.DebugMode != StateHasChangedDebugMode.Off)
+                if (StateHasChanged.DebugMode != StateHasChangedDebugMode.Off)
                 {
-                    Console.WriteLine($"WARNING: {GetType().Name} called empty StateHasChangedConfig.Action. Make sure to set `[YourViewModel].StateHasChangedConfig.Action = StateHasChanged;` in OnInitializedAsync()");
+                    Console.WriteLine($"WARNING: {GetType().Name} called the empty StateHasChanged.Action method. Make sure to set `[YourViewModel].StateHasChanged.Action = StateHasChanged;` in OnInitializedAsync()");
                 }
             };
         }

--- a/src/CloudNimble.BlazorEssentials/Merlin/Operation.cs
+++ b/src/CloudNimble.BlazorEssentials/Merlin/Operation.cs
@@ -136,7 +136,7 @@ namespace CloudNimble.BlazorEssentials.Merlin
                     RaisePropertyChanged(() => Status);
                     if (shouldObserveStatus)
                     {
-                        StateHasChangedAction();
+                        StateHasChangedConfig.Action();
                     }
                 }
             }
@@ -374,7 +374,7 @@ namespace CloudNimble.BlazorEssentials.Merlin
         {
             if (shouldObserveStatus)
             {
-                StateHasChangedAction();
+                StateHasChangedConfig.Action();
             }
         }
 

--- a/src/CloudNimble.BlazorEssentials/Merlin/Operation.cs
+++ b/src/CloudNimble.BlazorEssentials/Merlin/Operation.cs
@@ -136,7 +136,7 @@ namespace CloudNimble.BlazorEssentials.Merlin
                     RaisePropertyChanged(() => Status);
                     if (shouldObserveStatus)
                     {
-                        StateHasChangedConfig.Action();
+                        StateHasChanged.Action();
                     }
                 }
             }
@@ -374,7 +374,7 @@ namespace CloudNimble.BlazorEssentials.Merlin
         {
             if (shouldObserveStatus)
             {
-                StateHasChangedConfig.Action();
+                StateHasChanged.Action();
             }
         }
 

--- a/src/CloudNimble.BlazorEssentials/Merlin/Wizard.razor
+++ b/src/CloudNimble.BlazorEssentials/Merlin/Wizard.razor
@@ -269,7 +269,7 @@
         }
 
         // wire up the operation so that it can notify the wizard
-        Operation.StateHasChangedAction = StateHasChanged;
+        Operation.StateHasChangedConfig.Action = StateHasChanged;
         Operation.PropertyChanged += Operation_PropertyChanged;
     }
 
@@ -293,7 +293,7 @@
     void IDisposable.Dispose()
     {
         Operation.PropertyChanged -= Operation_PropertyChanged;
-        Operation.StateHasChangedAction = null;
+        Operation.StateHasChangedConfig.Action = null;
     }
 
 }

--- a/src/CloudNimble.BlazorEssentials/Merlin/Wizard.razor
+++ b/src/CloudNimble.BlazorEssentials/Merlin/Wizard.razor
@@ -269,7 +269,7 @@
         }
 
         // wire up the operation so that it can notify the wizard
-        Operation.StateHasChangedConfig.Action = StateHasChanged;
+        Operation.StateHasChanged.Action = StateHasChanged;
         Operation.PropertyChanged += Operation_PropertyChanged;
     }
 
@@ -293,7 +293,7 @@
     void IDisposable.Dispose()
     {
         Operation.PropertyChanged -= Operation_PropertyChanged;
-        Operation.StateHasChangedConfig.Action = null;
+        Operation.StateHasChanged.Action = null;
     }
 
 }

--- a/src/CloudNimble.BlazorEssentials/StateHasChangedConfig.cs
+++ b/src/CloudNimble.BlazorEssentials/StateHasChangedConfig.cs
@@ -1,0 +1,153 @@
+﻿using CloudNimble.BlazorEssentials.Threading;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudNimble.BlazorEssentials
+{
+    public class StateHasChangedConfig : IDisposable
+    {
+
+        #region Private Members
+
+        private Action stateHasChangedAction;
+        private readonly DelayDispatcher delayDispatcher = new();
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Allows the current Blazor container to pass the StateHasChanged action back to the BlazorObservable so ViewModel operations can 
+        /// trigger state changes.
+        /// </summary>
+        /// <remarks>
+        /// Will optionally drop intermediate StateHasChanged calls in a rapidly-updating environment, based on <see cref="DelayMode"/> 
+        /// and <see cref="DelayInterval"/>.
+        /// </remarks>
+        public Action Action
+        {
+            get
+            {
+                return DelayMode switch
+                {
+                    StateHasChangedDelayMode.Debounce => () => delayDispatcher.Debounce(DelayInterval, _ => InternalAction()),
+                    StateHasChangedDelayMode.Throttle => () => delayDispatcher.Throttle(DelayInterval, _ => InternalAction()),
+                    _ => () => InternalAction()
+                };
+            }
+            set
+            {
+                stateHasChangedAction = value;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// This is public so 
+        /// </remarks>
+        public int Count { get; set; }
+
+        /// <summary>
+        /// Flag for whether or not the render count and helpful debug feedback/warnings should be logged to the <see cref="Console"/>.
+        /// Default is false.
+        /// </summary>
+        public StateHasChangedDebugMode DebugMode { get; set; }
+
+        /// <summary>
+        /// An <see cref="int"/> specifying the number of milliseconds this BlazorObservable should wait between 
+        /// <see cref="Action"/> calls. Default is 100 miliseconds.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="DelayMode" /> must be set to <see cref="StateHasChangedDelayMode.Debounce" /> or 
+        /// <see cref="StateHasChangedDelayMode.Throttle" /> for this setting to take effect.
+        /// </remarks>
+        public int DelayInterval { get; set; } = 100;
+
+        /// <summary>
+        /// A <see cref="DelayMode" /> indicating whether or not this BlazorObservable should reduce the number of times
+        /// <see cref="Action" /> should be called in a given <see cref="DelayInterval" />
+        /// Default is <see cref="StateHasChangedDelayMode.Off"/>.
+        /// </summary>
+        public StateHasChangedDelayMode DelayMode { get; set; } = StateHasChangedDelayMode.Off;
+
+        /// <summary>
+        /// The <see cref="BlazorObservable"/> that this config is for.
+        /// </summary>
+        public BlazorObservable BlazorObservable { get; set; }
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        internal void LogDelay()
+        {
+            Console.WriteLine($"{BlazorObservable.GetType().Name}: StateHasChanged #{Count} called @ {DateTime.UtcNow.ToString("hh:mm:ss.fff", CultureInfo.InvariantCulture)} " +
+                $"{(DebugMode != StateHasChangedDebugMode.Off ? $"after {delayDispatcher.DelayCount} dropped calls." : "")}");
+
+            if (DebugMode != StateHasChangedDebugMode.Tuning || DelayMode == StateHasChangedDelayMode.Off) return;
+
+            var diffMiliseconds = DateTime.UtcNow.Subtract(delayDispatcher.TimerStarted).TotalMilliseconds;
+
+            // RWM: We're going to use a Tuple switch statement to simplify 
+            var entry = (DelayMode, DelayInterval, delayDispatcher.DelayCount, diffMiliseconds) switch
+            {
+                (StateHasChangedDelayMode.Debounce, _, _, < 50) => $"Performance: Debounce waited {diffMiliseconds}ms between calls. Delay was imperceptible.",
+
+                (StateHasChangedDelayMode.Debounce, _, _, < 2000) => $"Performance: Debounce waited {diffMiliseconds}ms between calls. Delay was noticeable.",
+
+                (StateHasChangedDelayMode.Throttle, < 50, _, _) => $"Performance: Throttle waited {DelayInterval}ms between calls. Delay was imperceptible.",
+
+                (StateHasChangedDelayMode.Throttle, < 2000, < 10, _) => $"Performance: Throttle waited {DelayInterval}ms between calls," +
+                    $" but there were fewer than 10 calls dropped. Delay was imperceptible, but consider using Debounce instead.",
+
+                (StateHasChangedDelayMode.Throttle, < 2000, _, _) => $"Performance: Throttle waited {DelayInterval}ms between calls." +
+                    $" If your goal is to reduce the number of repaints but fire them consistently, this is the right setting.",
+
+                _ => $"Performance: {DelayMode} waited {(DelayMode == StateHasChangedDelayMode.Debounce ? diffMiliseconds : DelayInterval)}ms " +
+                    $"between calls. Delay was unacceptable. Consider adding a visual 'waiting' indicator for the end user."
+            };
+
+            //if (string.IsNullOrWhiteSpace(entry)) return;
+            Console.WriteLine(entry);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// RWM: DO NOT change this method. Doing anything other than returning the StateHasChangedConfig.Action
+        /// will cause an infinite loop!
+        /// </remarks>
+        internal void InternalAction()
+        {
+            ++Count;
+
+            stateHasChangedAction();
+
+            if (DebugMode == StateHasChangedDebugMode.Off) return;
+
+            LogDelay();
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        public void Dispose()
+        {
+            delayDispatcher.Dispose();
+        }
+
+        #endregion
+
+    }
+}

--- a/src/CloudNimble.BlazorEssentials/Threading/DelayDispatcher.cs
+++ b/src/CloudNimble.BlazorEssentials/Threading/DelayDispatcher.cs
@@ -29,6 +29,7 @@ namespace CloudNimble.BlazorEssentials.Threading
 
         private bool disposedValue;
         private Timer timer;
+        private Dispatcher dispatcher = Dispatcher.CreateDefault();
         private Action<object> action;
         private object param;
 
@@ -50,6 +51,8 @@ namespace CloudNimble.BlazorEssentials.Threading
         public DateTime TimerStarted { get; internal set; }
 
         #endregion
+
+        #region Public Methods
 
         /// <summary>
         /// Debounce an event by resetting the event timeout every time the event is 
@@ -90,7 +93,6 @@ namespace CloudNimble.BlazorEssentials.Threading
 
                 timer?.Stop();
                 timer = null;
-                var dispatcher = Dispatcher.CreateDefault();
                 dispatcher.InvokeAsync(() => action.Invoke(param));
                 DelayCount = 0;
             };
@@ -125,7 +127,6 @@ namespace CloudNimble.BlazorEssentials.Threading
 
                     timer?.Stop();
                     timer = null;
-                    var dispatcher = Dispatcher.CreateDefault();
                     dispatcher.InvokeAsync(() => this.action.Invoke(this.param));
                     DelayCount = 0;
                 };
@@ -134,6 +135,8 @@ namespace CloudNimble.BlazorEssentials.Threading
                 TimerStarted = DateTime.UtcNow;
             }
         }
+
+        #endregion
 
         #region IDisposable
 

--- a/src/CloudNimble.BlazorEssentials/ViewModelBase.cs
+++ b/src/CloudNimble.BlazorEssentials/ViewModelBase.cs
@@ -53,7 +53,9 @@ namespace CloudNimble.BlazorEssentials
         /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> instance injected from the DI container.</param>
         /// <param name="configuration">The <typeparamref name="TConfig"/> instance injected from the DI container.</param>
         /// <param name="appState">The <typeparamref name="TAppState"/> instance injected from the DI container.</param>
-        public ViewModelBase(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, TConfig configuration = null, TAppState appState = null)
+        /// <param name="stateHasChangedConfig"></param>
+        public ViewModelBase(NavigationManager navigationManager, IHttpClientFactory httpClientFactory, TConfig configuration = null, TAppState appState = null, StateHasChangedConfig stateHasChangedConfig = null)
+            : base(stateHasChangedConfig)
         {
             NavigationManager = navigationManager;
             HttpClientFactory = httpClientFactory;


### PR DESCRIPTION
- Moved `StateHasChanged`-related properties to a separate class.
- Improved the API surface for discoverability.
- Added `TestableWebAssemblyHostEnvironment` to handle the new property injected into `AppStateBase` in testing.
- Ensured `AppStateBase` and `ViewModelBase` constructors fall through to `BlazorObservable`'s constructor.
- Added unit tests to cover `StateHasChanged` delay scenarios.