### PR TITLE
Fix IndexAttribute multiple usage and 404 for js import

### DIFF
--- a/src/CloudNimble.BlazorEssentials.IndexedDb/Attributes/IndexAttribute.cs
+++ b/src/CloudNimble.BlazorEssentials.IndexedDb/Attributes/IndexAttribute.cs
@@ -6,7 +6,7 @@ namespace CloudNimble.BlazorEssentials.IndexedDb
     /// <summary>
     /// 
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
     public class IndexAttribute : Attribute
     {
 

--- a/src/CloudNimble.BlazorEssentials.IndexedDb/IndexedDbDatabase.cs
+++ b/src/CloudNimble.BlazorEssentials.IndexedDb/IndexedDbDatabase.cs
@@ -55,7 +55,7 @@ namespace CloudNimble.BlazorEssentials.IndexedDb
         public IndexedDbDatabase(IJSRuntime jsRuntime)
         {
             _jsRuntime = jsRuntime;
-            _indexedDbModuleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/CloudNimble.BlazorEssentials.IndexedDB/CloudNimble.BlazorEssentials.IndexedDB.js").AsTask());
+            _indexedDbModuleTask = new(() => jsRuntime.InvokeAsync<IJSObjectReference>("import", "../_content/BlazorEssentials.IndexedDB/CloudNimble.BlazorEssentials.IndexedDB.js").AsTask());
             Name = GetType().Name;
 
             foreach (var prop in GetType().GetProperties().Where(c => typeof(IndexedDbObjectStore).IsAssignableFrom(c.PropertyType)))
@@ -90,7 +90,7 @@ namespace CloudNimble.BlazorEssentials.IndexedDb
             }
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Opens the IndexedDB defined in the DbDatabase. Under the covers will create the database if it does not exist


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->
<!-- Pull Request Template created by CloudNimble, Inc. --> 

### Summary
- Fix module import path
- Replace `./` with `../` import path to work with different app base paths eg: `<base href="/Custom/" />`
- Allow `Index` attribute to be used multiple times

### Associated Issues
- This pull request fixes #16

### Assemblies, Frameworks and Libraries

- CloudNimble.BlazorEssentials.IndexedDb

### Checklist (Uncheck if it is not completed)
- [ ] *N/A - Checklist review not required*
- [ ] *Test cases added*
- [ ] *Requires documentation updates*
- [x] *Build Validation Passed*
